### PR TITLE
fix: generate coordinate cells so the Coords toggle actually works

### DIFF
--- a/templates/back.html
+++ b/templates/back.html
@@ -18,7 +18,7 @@
 
   <!-- Puzzle display theme -->
   <figure>
-    <c:chess id="fen_fig" class="cdig"></c:chess>
+    <c:chess id="fen_fig" class="cdig" border="a1"></c:chess>
   </figure>
 
   <!-- Barre d’actions sobre -->
@@ -799,6 +799,7 @@ function setCoordsVisible(show) {
   document.documentElement.classList.toggle('coords-hidden', !show);
   var btn = document.getElementById('coords-toggle');
   if (btn) btn.classList.toggle('coords-on', show);
+  scheduleBoardFit();
 }
 
 function initCoordsToggle() {

--- a/templates/front.html
+++ b/templates/front.html
@@ -18,7 +18,7 @@
 
   <!-- Puzzle display theme -->
   <figure>
-    <c:chess id="fen_fig" class="cdig"></c:chess>
+    <c:chess id="fen_fig" class="cdig" border="a1"></c:chess>
   </figure>
 
   <!-- Puzzle to move pill + coords toggle -->
@@ -839,6 +839,7 @@ function setCoordsVisible(show) {
   document.documentElement.classList.toggle('coords-hidden', !show);
   var btn = document.getElementById('coords-toggle');
   if (btn) btn.classList.toggle('coords-on', show);
+  scheduleBoardFit();
 }
 
 function initCoordsToggle() {


### PR DESCRIPTION
## Summary

- The "Coords" button added in #14 had no visible effect: clicking it added/removed the `.coords-hidden` CSS class correctly, but there were never any `td.cols` / `td.rows` elements in the DOM to show or hide.
- Root cause: HTMLTTChess only generates coordinate cells when the `<c:chess>` element carries a `border` attribute containing a board-origin coordinate (e.g. `"a1"`). Without it, `isCoordShown` stays `false` inside `parseattrBorder()` and the engine skips generating all `td.cols` / `td.rows` cells entirely.
- Fix: add `border="a1"` to `<c:chess id="fen_fig">` in both `front.html` and `back.html`. `"a1"` tells the engine the board starts at a1 (the standard full 8×8 view), producing column labels a–h and rank labels 1–8 on all four sides. The existing `.coords-hidden` CSS rule then hides them by default; the Coords button reveals them.
- Also call `scheduleBoardFit()` inside `setCoordsVisible()` so the board re-scales correctly when coordinate labels appear or disappear (they change the table dimensions).

## Test plan
- [ ] Build sample deck: `python build_apkg.py --sample` — CI green
- [ ] Import into Anki — boards render as before (coords hidden by default)
- [ ] Click "Coords" button on front card → coordinate labels appear on all four sides of the board; button turns dark
- [ ] Click again → labels disappear; button returns to normal
- [ ] Flip to back card — same toggle, same persisted state
- [ ] Verify board re-sizes correctly when toggling (no overflow or misalignment)
- [ ] Verify both `theme-solarized` and `theme-paper-sand` show correct coord colors

https://claude.ai/code/session_018TziS5iezzvUKzuahh35ke

---
_Generated by [Claude Code](https://claude.ai/code/session_018TziS5iezzvUKzuahh35ke)_