### PR TITLE
fix: coordinate styling — 2-sided display, theme colors, smaller button

### DIFF
--- a/templates/back.html
+++ b/templates/back.html
@@ -18,7 +18,7 @@
 
   <!-- Puzzle display theme -->
   <figure>
-    <c:chess id="fen_fig" class="cdig" border="a1"></c:chess>
+    <c:chess id="fen_fig" class="cdig" border="a1 so"></c:chess>
   </figure>
 
   <!-- Barre d’actions sobre -->
@@ -26,7 +26,7 @@
     <a class="btn lichess" href="https://lichess.org/analysis/{{FEN}}">Lichess Analysis</a>
     <a class="btn lichess" href="https://lichess.org/training/{{PuzzleID}}">Lichess Puzzle</a>
     <a class="btn chesscom" href="https://chess.com/analysis?fen={{FEN}}">Chess.com Analysis</a>
-    <button class="btn" id="coords-toggle" type="button">Coords</button>
+    <button class="btn btn-sm" id="coords-toggle" type="button">Coords</button>
   </nav>
 
   <div class="puzzle-meta">

--- a/templates/front.html
+++ b/templates/front.html
@@ -18,13 +18,13 @@
 
   <!-- Puzzle display theme -->
   <figure>
-    <c:chess id="fen_fig" class="cdig" border="a1"></c:chess>
+    <c:chess id="fen_fig" class="cdig" border="a1 so"></c:chess>
   </figure>
 
   <!-- Puzzle to move pill + coords toggle -->
   <div class="puzzle-meta">
     <h2 id="to_move" class="clean-pill"></h2>
-    <button class="btn" id="coords-toggle" type="button">Coords</button>
+    <button class="btn btn-sm" id="coords-toggle" type="button">Coords</button>
   </div>
 </div>
 

--- a/templates/style.css
+++ b/templates/style.css
@@ -156,8 +156,6 @@ table.chess div.pcfg { color: var(--piece-b); }
 table.chess td.cols,
 table.chess td.rows {
   color: var(--coord);
-  font-family: system-ui, -apple-system, sans-serif !important;
-  font-size: 0.35em;
 }
 
 .coords-hidden table.chess td.cols,
@@ -264,6 +262,12 @@ table.chess td.rows {
 
 .btn.chesscom:active {
   background: #6E8F40;
+}
+
+/* Small button variant */
+.btn-sm {
+  font-size: 11px;
+  padding: 5px 10px;
 }
 
 /* Coords toggle — active/on state */


### PR DESCRIPTION
## Summary

Three issues with the coordinate display introduced in #15:

### 1. Wrong font override
`font-family: system-ui !important` and `font-size: 0.35em` were applied to `td.cols` / `td.rows`. This broke the rendering: the Chess Merida Unicode font renders plain ASCII `a`–`h` and `1`–`8` as coordinate glyphs sized exactly to match the board squares (1em each). Overriding to system-ui made the letters appear as tiny misaligned plain text with no relation to the square grid. Only `color: var(--coord)` is needed to theme the coordinates.

### 2. All 4 sides showing
`border="a1"` generates coordinate labels on all four sides of the board. Modern chess boards display them on **2 sides only**: file letters (a–h) at the bottom, rank numbers (1–8) on the left. Changed to `border="a1 so"` — `"a1"` sets the board origin (enabling coord generation), `"so"` restricts display to south (bottom) + west (left) via HTMLTTChess NSEO notation.

### 3. Button too large
Added `.btn-sm` (11px font, 5px/10px padding) and applied it to `#coords-toggle` so the button is visually lighter than the Lichess/Chess.com action links.

## Test plan
- [ ] CI green
- [ ] Import into Anki — boards render as before (coords hidden by default)
- [ ] Click "Coords": file letters appear on bottom row, rank numbers on left column, using the theme's `--coord` color
- [ ] "Coords" button is noticeably smaller than the Lichess/Chess.com buttons on the back card
- [ ] Both `theme-solarized` and `theme-paper-sand` show distinct coord colors

https://claude.ai/code/session_018TziS5iezzvUKzuahh35ke

---
_Generated by [Claude Code](https://claude.ai/code/session_018TziS5iezzvUKzuahh35ke)_