### PR TITLE
fix(i18n): move lang/dict to module scope and translate coords button

### DIFF
--- a/templates/back.html
+++ b/templates/back.html
@@ -692,6 +692,24 @@ function rotateFen180(fenPieces) {
     .join('/');
 }
 
+// i18n: detected once at module scope so all functions share lang/dict
+const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+const labels = {
+  fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coords"   },
+  de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    coords: "Koord."   },
+  es: { white: "Juegan blancas",    black: "Juegan negras",     coords: "Coord."   },
+  it: { white: "Il bianco muove",   black: "Il nero muove",     coords: "Coord."   },
+  pt: { white: "Brancas jogam",     black: "Pretas jogam",      coords: "Coord."   },
+  nl: { white: "Wit aan zet",       black: "Zwart aan zet",     coords: "Koord."   },
+  ru: { white: "Ход белых",         black: "Ход чёрных",        coords: "Коорд."   },
+  zh: { white: "白方走",            black: "黑方走",             coords: "坐标"     },
+  ja: { white: "白番",              black: "黒番",               coords: "座標"     },
+  pl: { white: "Ruch białych",      black: "Ruch czarnych",     coords: "Koord."   },
+  tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    coords: "Koord."   },
+  en: { white: "White to move",     black: "Black to move",     coords: "Coords"   }
+};
+const dict = labels[lang] || labels.en;
+
 function applyFenToBoard() {
   // 1) Read and normalize FEN (only need first 2 fields: placement + side)
   const raw = ('{{FEN}}' || '').trim();
@@ -700,29 +718,11 @@ function applyFenToBoard() {
   // 2) Determine side to move (strict on first char, case-insensitive)
   const side = sideRaw.toLowerCase().startsWith('w') ? 'w' : 'b';
 
-  // 3) Localized labels (maintained inline for portability)
-  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
-  const labels = {
-    fr: { white: "Trait aux blancs", black: "Trait aux noirs" },
-    de: { white: "Weiß am Zug",     black: "Schwarz am Zug"  },
-    es: { white: "Juegan blancas",  black: "Juegan negras"   },
-    it: { white: "Il bianco muove", black: "Il nero muove"   },
-    pt: { white: "Brancas jogam",   black: "Pretas jogam"    },
-    nl: { white: "Wit aan zet",     black: "Zwart aan zet"   },
-    ru: { white: "Ход белых",       black: "Ход чёрных"      },
-    zh: { white: "白方走",          black: "黑方走"          },
-    ja: { white: "白番",            black: "黒番"            },
-    pl: { white: "Ruch białych",    black: "Ruch czarnych"   },
-    tr: { white: "Beyazlar oynar",  black: "Siyahlar oynar"  },
-    en: { white: "White to move",   black: "Black to move"   }
-  };
-  const dict = labels[lang] || labels.en;
-
-  // 4) Orient the piece-placement for HTMLTTChess
+  // 3) Orient the piece-placement for HTMLTTChess
   //    Pass only the placement (field #1) to <c:chess>; rotate 180° when Black to move.
   const oriented = side === 'w' ? placement : rotateFen180(placement);
 
-  // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
+  // 4) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
   if (fig) fig.textContent = oriented;
@@ -803,8 +803,9 @@ function setCoordsVisible(show) {
 }
 
 function initCoordsToggle() {
-  setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
   var btn = document.getElementById('coords-toggle');
+  if (btn) btn.textContent = dict.coords;
+  setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
   if (btn) btn.addEventListener('click', function() {
     var next = document.documentElement.classList.contains('coords-hidden');
     localStorage.setItem('ocp_coords', next);

--- a/templates/front.html
+++ b/templates/front.html
@@ -680,6 +680,24 @@ function rotateFen180(fenPieces) {
     .join('/');
 }
 
+// i18n: detected once at module scope so all functions share lang/dict
+const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+const labels = {
+  fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coords"   },
+  de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    moves: "Finde die Zugfolge",                    coords: "Koord."   },
+  es: { white: "Juegan blancas",    black: "Juegan negras",     moves: "Encuentra la secuencia de movimientos", coords: "Coord."   },
+  it: { white: "Il bianco muove",   black: "Il nero muove",     moves: "Trova la sequenza di mosse",            coords: "Coord."   },
+  pt: { white: "Brancas jogam",     black: "Pretas jogam",      moves: "Encontre a sequência de movimentos",    coords: "Coord."   },
+  nl: { white: "Wit aan zet",       black: "Zwart aan zet",     moves: "Vind de zetvolgorde",                   coords: "Koord."   },
+  ru: { white: "Ход белых",         black: "Ход чёрных",        moves: "Найдите последовательность ходов",      coords: "Коорд."   },
+  zh: { white: "白方走",            black: "黑方走",             moves: "找出棋步顺序",                          coords: "坐标"     },
+  ja: { white: "白番",              black: "黒番",               moves: "手順を見つける",                        coords: "座標"     },
+  pl: { white: "Ruch białych",      black: "Ruch czarnych",     moves: "Znajdź sekwencję ruchów",               coords: "Koord."   },
+  tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    moves: "Hamle sırasını bul",                    coords: "Koord."   },
+  en: { white: "White to move",     black: "Black to move",     moves: "Find the move sequence",                coords: "Coords"   }
+};
+const dict = labels[lang] || labels.en;
+
 function applyFenToBoard() {
   // 1) Read and normalize FEN (only need first 2 fields: placement + side)
   const raw = ('{{FEN}}' || '').trim();
@@ -688,85 +706,19 @@ function applyFenToBoard() {
   // 2) Determine side to move (strict on first char, case-insensitive)
   const side = sideRaw.toLowerCase().startsWith('w') ? 'w' : 'b';
 
-  // 3) Localized labels (maintained inline for portability)
-  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
-const labels = {
-  fr: {
-    white: "Trait aux blancs",
-    black: "Trait aux noirs",
-    moves: "Trouvez la séquence de coups"
-  },
-  de: {
-    white: "Weiß am Zug",
-    black: "Schwarz am Zug",
-    moves: "Finde die Zugfolge"
-  },
-  es: {
-    white: "Juegan blancas",
-    black: "Juegan negras",
-    moves: "Encuentra la secuencia de movimientos"
-  },
-  it: {
-    white: "Il bianco muove",
-    black: "Il nero muove",
-    moves: "Trova la sequenza di mosse"
-  },
-  pt: {
-    white: "Brancas jogam",
-    black: "Pretas jogam",
-    moves: "Encontre a sequência de movimentos"
-  },
-  nl: {
-    white: "Wit aan zet",
-    black: "Zwart aan zet",
-    moves: "Vind de zetvolgorde"
-  },
-  ru: {
-    white: "Ход белых",
-    black: "Ход чёрных",
-    moves: "Найдите последовательность ходов"
-  },
-  zh: {
-    white: "白方走",
-    black: "黑方走",
-    moves: "找出棋步顺序"
-  },
-  ja: {
-    white: "白番",
-    black: "黒番",
-    moves: "手順を見つける"
-  },
-  pl: {
-    white: "Ruch białych",
-    black: "Ruch czarnych",
-    moves: "Znajdź sekwencję ruchów"
-  },
-  tr: {
-    white: "Beyazlar oynar",
-    black: "Siyahlar oynar",
-    moves: "Hamle sırasını bul"
-  },
-  en: {
-    white: "White to move",
-    black: "Black to move",
-    moves: "Find the move sequence"
-  }
-};  const dict = labels[lang] || labels.en;
-
-  // 4) Orient the piece-placement for HTMLTTChess
+  // 3) Orient the piece-placement for HTMLTTChess
   //    Pass only the placement (field #1) to <c:chess>; rotate 180° when Black to move.
   const oriented = side === 'w' ? placement : rotateFen180(placement);
 
-  // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
+  // 4) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
   if (fig) fig.textContent = oriented;
   if (toMove) toMove.textContent = side === 'w' ? dict.white : dict.black;
 
-  // 6) display moves string
+  // 5) display moves string
   const Moves = document.getElementById('moves');
   if (Moves) Moves.textContent = dict.moves;
-
 }
 
 /* ----- Fix font-size bug -------------------------------------------------------- */
@@ -843,8 +795,9 @@ function setCoordsVisible(show) {
 }
 
 function initCoordsToggle() {
-  setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
   var btn = document.getElementById('coords-toggle');
+  if (btn) btn.textContent = dict.coords;
+  setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
   if (btn) btn.addEventListener('click', function() {
     var next = document.documentElement.classList.contains('coords-hidden');
     localStorage.setItem('ocp_coords', next);


### PR DESCRIPTION
## Summary

- **Fix i18n detection scope** : `lang`, `labels` et `dict` étaient définis à l'intérieur de `applyFenToBoard()`, les rendant inaccessibles aux autres fonctions (notamment `initCoordsToggle()`). Ils sont maintenant au niveau module, détectés une seule fois et partagés par toutes les fonctions.
- **Traduction du bouton Coords** : `initCoordsToggle()` applique désormais `dict.coords` au texte du bouton. Traductions ajoutées pour les 12 langues supportées (fr/Coords, de/Koord., es‑it‑pt/Coord., nl/Koord., ru/Коорд., zh/坐标, ja/座標, pl‑tr/Koord., en/Coords).
- **Correction d'indentation** : le bloc `labels` dans `front.html` était à colonne 0 à l'intérieur d'une fonction — corrigé.
- **Harmonisation** : `back.html` adopte la même structure de `labels` que `front.html` (mêmes langues, même ordre de propriétés).

## Test plan

- [ ] Ouvrir une carte front/back en anglais → bouton affiche "Coords", "White to move" / "Black to move"
- [ ] Changer la langue du navigateur/système en français → bouton affiche "Coords", "Trait aux blancs/noirs"
- [ ] Tester avec une autre langue (ex. de, ja) → libellés et bouton traduits correctement
- [ ] Vérifier que le toggle coords fonctionne toujours (affiche/masque les coordonnées)
- [ ] Vérifier que la préférence coords est persistée via localStorage

https://claude.ai/code/session_01W4q82SG7ivHr15HiowDczK

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4q82SG7ivHr15HiowDczK)_