### PR TITLE
fix(i18n): keep lang/labels/dict function-scoped to fix Anki redeclaration crash

### DIFF
--- a/templates/back.html
+++ b/templates/back.html
@@ -692,24 +692,6 @@ function rotateFen180(fenPieces) {
     .join('/');
 }
 
-// i18n: detected once at module scope so all functions share lang/dict
-const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
-const labels = {
-  fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coords"   },
-  de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    coords: "Koord."   },
-  es: { white: "Juegan blancas",    black: "Juegan negras",     coords: "Coord."   },
-  it: { white: "Il bianco muove",   black: "Il nero muove",     coords: "Coord."   },
-  pt: { white: "Brancas jogam",     black: "Pretas jogam",      coords: "Coord."   },
-  nl: { white: "Wit aan zet",       black: "Zwart aan zet",     coords: "Koord."   },
-  ru: { white: "Ход белых",         black: "Ход чёрных",        coords: "Коорд."   },
-  zh: { white: "白方走",            black: "黑方走",             coords: "坐标"     },
-  ja: { white: "白番",              black: "黒番",               coords: "座標"     },
-  pl: { white: "Ruch białych",      black: "Ruch czarnych",     coords: "Koord."   },
-  tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    coords: "Koord."   },
-  en: { white: "White to move",     black: "Black to move",     coords: "Coords"   }
-};
-const dict = labels[lang] || labels.en;
-
 function applyFenToBoard() {
   // 1) Read and normalize FEN (only need first 2 fields: placement + side)
   const raw = ('{{FEN}}' || '').trim();
@@ -718,15 +700,40 @@ function applyFenToBoard() {
   // 2) Determine side to move (strict on first char, case-insensitive)
   const side = sideRaw.toLowerCase().startsWith('w') ? 'w' : 'b';
 
-  // 3) Orient the piece-placement for HTMLTTChess
+  // 3) Localized labels — kept inside the function so const declarations stay
+  //    function-scoped and never conflict when both card faces share the same
+  //    JS context (Anki reuses the WebView; module-level const would throw
+  //    "already declared" on the second template script).
+  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+  const labels = {
+    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coords"   },
+    de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    coords: "Koord."   },
+    es: { white: "Juegan blancas",    black: "Juegan negras",     coords: "Coord."   },
+    it: { white: "Il bianco muove",   black: "Il nero muove",     coords: "Coord."   },
+    pt: { white: "Brancas jogam",     black: "Pretas jogam",      coords: "Coord."   },
+    nl: { white: "Wit aan zet",       black: "Zwart aan zet",     coords: "Koord."   },
+    ru: { white: "Ход белых",         black: "Ход чёрных",        coords: "Коорд."   },
+    zh: { white: "白方走",            black: "黑方走",             coords: "坐标"     },
+    ja: { white: "白番",              black: "黒番",               coords: "座標"     },
+    pl: { white: "Ruch białych",      black: "Ruch czarnych",     coords: "Koord."   },
+    tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    coords: "Koord."   },
+    en: { white: "White to move",     black: "Black to move",     coords: "Coords"   }
+  };
+  const dict = labels[lang] || labels.en;
+
+  // 4) Orient the piece-placement for HTMLTTChess
   //    Pass only the placement (field #1) to <c:chess>; rotate 180° when Black to move.
   const oriented = side === 'w' ? placement : rotateFen180(placement);
 
-  // 4) Minimal DOM updates (textContent avoids accidental HTML parsing)
+  // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
   if (fig) fig.textContent = oriented;
   if (toMove) toMove.textContent = side === 'w' ? dict.white : dict.black;
+
+  // 6) coords button label (shared from same dict, avoids a second lang lookup)
+  const coordsBtn = document.getElementById('coords-toggle');
+  if (coordsBtn) coordsBtn.textContent = dict.coords;
 }
 
 /* ----- Fix font-size bug -------------------------------------------------------- */
@@ -803,9 +810,8 @@ function setCoordsVisible(show) {
 }
 
 function initCoordsToggle() {
-  var btn = document.getElementById('coords-toggle');
-  if (btn) btn.textContent = dict.coords;
   setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
+  var btn = document.getElementById('coords-toggle');
   if (btn) btn.addEventListener('click', function() {
     var next = document.documentElement.classList.contains('coords-hidden');
     localStorage.setItem('ocp_coords', next);

--- a/templates/back.html
+++ b/templates/back.html
@@ -706,7 +706,7 @@ function applyFenToBoard() {
   //    "already declared" on the second template script).
   const lang = ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
   const labels = {
-    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coords"   },
+    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coord."   },
     de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    coords: "Koord."   },
     es: { white: "Juegan blancas",    black: "Juegan negras",     coords: "Coord."   },
     it: { white: "Il bianco muove",   black: "Il nero muove",     coords: "Coord."   },

--- a/templates/back.html
+++ b/templates/back.html
@@ -704,7 +704,7 @@ function applyFenToBoard() {
   //    function-scoped and never conflict when both card faces share the same
   //    JS context (Anki reuses the WebView; module-level const would throw
   //    "already declared" on the second template script).
-  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+  const lang = ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
   const labels = {
     fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   coords: "Coords"   },
     de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    coords: "Koord."   },

--- a/templates/front.html
+++ b/templates/front.html
@@ -692,7 +692,7 @@ function applyFenToBoard() {
   //    function-scoped and never conflict when both card faces share the same
   //    JS context (Anki reuses the WebView; module-level const would throw
   //    "already declared" on the second template script).
-  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+  const lang = ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
   const labels = {
     fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coords"   },
     de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    moves: "Finde die Zugfolge",                    coords: "Koord."   },

--- a/templates/front.html
+++ b/templates/front.html
@@ -680,24 +680,6 @@ function rotateFen180(fenPieces) {
     .join('/');
 }
 
-// i18n: detected once at module scope so all functions share lang/dict
-const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
-const labels = {
-  fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coords"   },
-  de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    moves: "Finde die Zugfolge",                    coords: "Koord."   },
-  es: { white: "Juegan blancas",    black: "Juegan negras",     moves: "Encuentra la secuencia de movimientos", coords: "Coord."   },
-  it: { white: "Il bianco muove",   black: "Il nero muove",     moves: "Trova la sequenza di mosse",            coords: "Coord."   },
-  pt: { white: "Brancas jogam",     black: "Pretas jogam",      moves: "Encontre a sequência de movimentos",    coords: "Coord."   },
-  nl: { white: "Wit aan zet",       black: "Zwart aan zet",     moves: "Vind de zetvolgorde",                   coords: "Koord."   },
-  ru: { white: "Ход белых",         black: "Ход чёрных",        moves: "Найдите последовательность ходов",      coords: "Коорд."   },
-  zh: { white: "白方走",            black: "黑方走",             moves: "找出棋步顺序",                          coords: "坐标"     },
-  ja: { white: "白番",              black: "黒番",               moves: "手順を見つける",                        coords: "座標"     },
-  pl: { white: "Ruch białych",      black: "Ruch czarnych",     moves: "Znajdź sekwencję ruchów",               coords: "Koord."   },
-  tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    moves: "Hamle sırasını bul",                    coords: "Koord."   },
-  en: { white: "White to move",     black: "Black to move",     moves: "Find the move sequence",                coords: "Coords"   }
-};
-const dict = labels[lang] || labels.en;
-
 function applyFenToBoard() {
   // 1) Read and normalize FEN (only need first 2 fields: placement + side)
   const raw = ('{{FEN}}' || '').trim();
@@ -706,19 +688,44 @@ function applyFenToBoard() {
   // 2) Determine side to move (strict on first char, case-insensitive)
   const side = sideRaw.toLowerCase().startsWith('w') ? 'w' : 'b';
 
-  // 3) Orient the piece-placement for HTMLTTChess
+  // 3) Localized labels — kept inside the function so const declarations stay
+  //    function-scoped and never conflict when both card faces share the same
+  //    JS context (Anki reuses the WebView; module-level const would throw
+  //    "already declared" on the second template script).
+  const lang = (navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
+  const labels = {
+    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coords"   },
+    de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    moves: "Finde die Zugfolge",                    coords: "Koord."   },
+    es: { white: "Juegan blancas",    black: "Juegan negras",     moves: "Encuentra la secuencia de movimientos", coords: "Coord."   },
+    it: { white: "Il bianco muove",   black: "Il nero muove",     moves: "Trova la sequenza di mosse",            coords: "Coord."   },
+    pt: { white: "Brancas jogam",     black: "Pretas jogam",      moves: "Encontre a sequência de movimentos",    coords: "Coord."   },
+    nl: { white: "Wit aan zet",       black: "Zwart aan zet",     moves: "Vind de zetvolgorde",                   coords: "Koord."   },
+    ru: { white: "Ход белых",         black: "Ход чёрных",        moves: "Найдите последовательность ходов",      coords: "Коорд."   },
+    zh: { white: "白方走",            black: "黑方走",             moves: "找出棋步顺序",                          coords: "坐标"     },
+    ja: { white: "白番",              black: "黒番",               moves: "手順を見つける",                        coords: "座標"     },
+    pl: { white: "Ruch białych",      black: "Ruch czarnych",     moves: "Znajdź sekwencję ruchów",               coords: "Koord."   },
+    tr: { white: "Beyazlar oynar",    black: "Siyahlar oynar",    moves: "Hamle sırasını bul",                    coords: "Koord."   },
+    en: { white: "White to move",     black: "Black to move",     moves: "Find the move sequence",                coords: "Coords"   }
+  };
+  const dict = labels[lang] || labels.en;
+
+  // 4) Orient the piece-placement for HTMLTTChess
   //    Pass only the placement (field #1) to <c:chess>; rotate 180° when Black to move.
   const oriented = side === 'w' ? placement : rotateFen180(placement);
 
-  // 4) Minimal DOM updates (textContent avoids accidental HTML parsing)
+  // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
   if (fig) fig.textContent = oriented;
   if (toMove) toMove.textContent = side === 'w' ? dict.white : dict.black;
 
-  // 5) display moves string
+  // 6) display moves string
   const Moves = document.getElementById('moves');
   if (Moves) Moves.textContent = dict.moves;
+
+  // 7) coords button label (shared from same dict, avoids a second lang lookup)
+  const coordsBtn = document.getElementById('coords-toggle');
+  if (coordsBtn) coordsBtn.textContent = dict.coords;
 }
 
 /* ----- Fix font-size bug -------------------------------------------------------- */
@@ -795,9 +802,8 @@ function setCoordsVisible(show) {
 }
 
 function initCoordsToggle() {
-  var btn = document.getElementById('coords-toggle');
-  if (btn) btn.textContent = dict.coords;
   setCoordsVisible(localStorage.getItem('ocp_coords') === 'true');
+  var btn = document.getElementById('coords-toggle');
   if (btn) btn.addEventListener('click', function() {
     var next = document.documentElement.classList.contains('coords-hidden');
     localStorage.setItem('ocp_coords', next);

--- a/templates/front.html
+++ b/templates/front.html
@@ -694,7 +694,7 @@ function applyFenToBoard() {
   //    "already declared" on the second template script).
   const lang = ((navigator.languages && navigator.languages[0]) || navigator.language || navigator.userLanguage || 'en').slice(0, 2).toLowerCase();
   const labels = {
-    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coords"   },
+    fr: { white: "Trait aux blancs",  black: "Trait aux noirs",   moves: "Trouvez la séquence de coups",          coords: "Coord."   },
     de: { white: "Weiß am Zug",       black: "Schwarz am Zug",    moves: "Finde die Zugfolge",                    coords: "Koord."   },
     es: { white: "Juegan blancas",    black: "Juegan negras",     moves: "Encuentra la secuencia de movimientos", coords: "Coord."   },
     it: { white: "Il bianco muove",   black: "Il nero muove",     moves: "Trova la sequenza di mosse",            coords: "Coord."   },

--- a/templates/style.css
+++ b/templates/style.css
@@ -270,6 +270,14 @@ table.chess td.rows {
   padding: 5px 10px;
 }
 
+/* Coords toggle — pinned to top-right corner, outside normal flow */
+#coords-toggle {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  z-index: 100;
+}
+
 /* Coords toggle — active/on state */
 .btn.coords-on {
   background: var(--sq-dark);


### PR DESCRIPTION
## Problème

Le PR #17 a cassé tout l'affichage en déplaçant `lang`, `labels` et `dict` au niveau module (`const` hors de toute fonction).

Anki réutilise le même contexte JavaScript pour les deux faces d'une carte. Quand le script du template back s'exécute après celui du front, les déclarations `const lang`, `const labels`, `const dict` au niveau module déclenchent :

```
SyntaxError: Identifier 'lang' has already been declared
```

Ce crash interrompt tout le script — le plateau d'échecs ne se rend plus, aucune traduction n'est appliquée.

## Fix

- Remettre `lang`, `labels`, `dict` **à l'intérieur de `applyFenToBoard()`** (portée fonction → ré-évaluable sans conflit).
- Le label du bouton coords est appliqué à l'étape 7 de cette même fonction — pas besoin de dépendance i18n dans `initCoordsToggle()`.
- Toutes les traductions du bouton coords (ajoutées dans #17) sont conservées.

## Test plan

- [ ] Afficher la face avant d'une carte → plateau rendu, "Trait aux blancs/noirs" en fr, bouton "Coords"
- [ ] Retourner la carte → face arrière rendue correctement, pas de JS error en console
- [ ] Vérifier avec plusieurs langues (de, ja…) que les labels s'affichent bien
- [ ] Toggle coords fonctionne et persiste

https://claude.ai/code/session_01W4q82SG7ivHr15HiowDczK

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4q82SG7ivHr15HiowDczK)_