### PR TITLE
fix: flip board coordinates for Black-to-move and prevent coord overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ The script downloads the **complete Lichess database** (several million puzzles)
 **Fundamental principle:** Instead of simply taking the most popular puzzles (which would create redundancies), the script applies a **maximum coverage algorithm by theme**:
 
 ```python
-def sample_by_themes(tranche, target_per_theme=20, popularity_threshold=90):
+def sample_by_themes(tranche, target_per_theme=17, popularity_threshold=90):
 ```
 
 **Selection steps:**
 1. **Theme identification**: Extract all tactical themes (fork, pin, discovered attack, etc.)
 2. **Quality filtering**: Priority selection of puzzles with Popularity ≥ 90%
-3. **Balanced distribution**: Maximum 20 puzzles per theme to avoid overrepresentation
+3. **Balanced distribution**: Maximum 17 puzzles per theme to avoid overrepresentation
 4. **Intelligent complement**: Add puzzles with lower popularity for rare themes
 
 ### **3. Exhaustive Coverage Guarantee 📊**

--- a/build_apkg.py
+++ b/build_apkg.py
@@ -326,7 +326,7 @@ def build_full(csv_dir: str, output: str) -> None:
     import lichess_optimized_puzzles_datasets as ld  # pylint: disable=import-outside-toplevel
     ld.download_puzzle_db()
     ld.decompress_zst()
-    stats = ld.extract_tranches(ld.CSV_FILE, target_per_theme=20, popularity_threshold=90)
+    stats = ld.extract_tranches(ld.CSV_FILE, target_per_theme=17, popularity_threshold=90)
     build_from_csvs(csv_dir, output, deck_stats=stats)
 
 

--- a/lichess_optimized_puzzles_datasets.py
+++ b/lichess_optimized_puzzles_datasets.py
@@ -172,7 +172,7 @@ def uci_seq_to_san(fen: str, uci_moves: str) -> str:
 
 def sample_by_themes(
     tranche: pandas.DataFrame,
-    target_per_theme: int = 30,
+    target_per_theme: int = 17,
     popularity_threshold: int = 90,
 ) -> List:
     """
@@ -185,7 +185,7 @@ def sample_by_themes(
     ----------
     tranche : pandas.DataFrame
         DataFrame containing puzzles for a specific ELO range
-    target_per_theme : int, default=30
+    target_per_theme : int, default=17
         Maximum number of puzzles to select per theme
     popularity_threshold : int, default=90
         Minimum popularity score for initial selection
@@ -225,7 +225,7 @@ def sample_by_themes(
 
 def extract_tranches(
     csv_file: str,
-    target_per_theme: int = 30,
+    target_per_theme: int = 17,
     popularity_threshold: int = 90,
 ) -> Dict[str, Dict]:
     """
@@ -240,7 +240,7 @@ def extract_tranches(
     ----------
     csv_file : str
         Path to the decompressed puzzle database CSV file
-    target_per_theme : int, default=30
+    target_per_theme : int, default=17
         Maximum puzzles per theme for balanced sampling
     popularity_threshold : int, default=90
         Minimum popularity threshold for quality filtering
@@ -413,7 +413,7 @@ def main() -> None:
     """
     download_puzzle_db()
     decompress_zst()
-    extract_tranches(CSV_FILE, target_per_theme=20, popularity_threshold=90)
+    extract_tranches(CSV_FILE, target_per_theme=17, popularity_threshold=90)
 
 
 if __name__ == "__main__":

--- a/templates/back.html
+++ b/templates/back.html
@@ -145,12 +145,15 @@ function detectIE() {
 }
 
 /* My Board object */
-function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
+function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass, _flip) {
     this.fenCode = _fenCode;
     this.attrBorder = _attrBorder.split(' ');
     this.colorMode = _colorMode;
     this.attrStyle = _attrStyle;
     this.attrClass = _attrClass;
+    // When the board is shown from Black's side (180° rotation), the coordinate
+    // labels must be mirrored: bottom-left becomes h1's mirror, not a1.
+    this.flip = !!_flip;
 
     this.rowCount = 0;
     this.colCount = 0;
@@ -321,6 +324,13 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
         var generatedHTML = '';
         this.attrClass = VALUE_CLASS_COLOR_TABLE + (this.attrClass == '' ? '' : ' ' + this.attrClass);
 
+        var colsLabels = MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount);
+        var rowsLabels = MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+        if (this.flip) {
+            colsLabels = colsLabels.split('').reverse().join('');
+            rowsLabels = rowsLabels.split('<br/>').filter(function (s) { return s !== ''; }).reverse().join('<br/>') + '<br/>';
+        }
+
         /* ----- Chess table ---------------------------------------------------------------------------------------------------- */
         generatedHTML +=
             '<table class="' + this.attrClass + '"' + (this.attrStyle != '' ? ' style="' + this.attrStyle + '"' : '') + '>';
@@ -332,7 +342,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
             generatedHTML +=
                 (this.isCoordShownLeft || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '<td class="cols">' +
-                MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount) +
+                colsLabels +
                 '</td>' +
                 (this.isCoordShownRight || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '';
@@ -354,7 +364,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
 
         if (this.isCoordShownLeft) {
             generatedHTML += '<td class="rows">';
-            generatedHTML += MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+            generatedHTML += rowsLabels;
             generatedHTML += '</td>';
         } else if (this.isCoordPadded) {
             generatedHTML += '<td class="rows">';
@@ -433,7 +443,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
 
         if (this.isCoordShownRight) {
             generatedHTML += '<td class="rows">';
-            generatedHTML += MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+            generatedHTML += rowsLabels;
             generatedHTML += '</td>';
         } else if (this.isCoordPadded) {
             generatedHTML += '<td class="rows">';
@@ -450,7 +460,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
             generatedHTML +=
                 (this.isCoordShownLeft || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '<td class="cols">' +
-                MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount) +
+                colsLabels +
                 '</td>' +
                 (this.isCoordShownRight || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '';
@@ -668,7 +678,8 @@ function parseChess() {
             boardFenCode = chessElt[idx].fenCode;
         }
 
-        var board = new ChessBoard(boardFenCode, attrBorder, attrMode, attrStyle, attrClass);
+        var attrFlip = chessElt[idx].getAttribute('data-flip') === '1';
+        var board = new ChessBoard(boardFenCode, attrBorder, attrMode, attrStyle, attrClass, attrFlip);
         var generatedHTML = board.generateHTML();
         if (generatedHTML.length == 0) {
             /* No board position given. Color mode is kept for upcoming chess tags. */
@@ -728,7 +739,10 @@ function applyFenToBoard() {
   // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
-  if (fig) fig.textContent = oriented;
+  if (fig) {
+    fig.textContent = oriented;
+    fig.setAttribute('data-flip', side === 'w' ? '0' : '1');
+  }
   if (toMove) toMove.textContent = side === 'w' ? dict.white : dict.black;
 
   // 6) coords button label (shared from same dict, avoids a second lang lookup)
@@ -741,9 +755,6 @@ function applyFenToBoard() {
 function fitChessBoardToScreen() {
   const table = document.querySelector('table.chess, table.bwchess');
   if (!table) return;
-
-  // Measure the real board box (more reliable than the table alone)
-  const board = table.querySelector('td.board > div.board') || table;
 
   // Reset any previous fitting
   table.style.zoom = '';
@@ -764,8 +775,9 @@ function fitChessBoardToScreen() {
   const maxW = Math.max(50, vw - margin * 2);
   const maxH = Math.max(50, vh - overhead - margin * 2);
 
-  // Measure actual current board size
-  const rect = board.getBoundingClientRect();
+  // Measure the full table (board + coordinate cells) so the right-hand
+  // coordinates never push the board off-screen when shown.
+  const rect = table.getBoundingClientRect();
 
   // Fit factor (never upscale; only shrink)
   let z = Math.min(maxW / rect.width, maxH / rect.height, 1);

--- a/templates/front.html
+++ b/templates/front.html
@@ -133,12 +133,15 @@ function detectIE() {
 }
 
 /* My Board object */
-function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
+function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass, _flip) {
     this.fenCode = _fenCode;
     this.attrBorder = _attrBorder.split(' ');
     this.colorMode = _colorMode;
     this.attrStyle = _attrStyle;
     this.attrClass = _attrClass;
+    // When the board is shown from Black's side (180° rotation), the coordinate
+    // labels must be mirrored: bottom-left becomes h1's mirror, not a1.
+    this.flip = !!_flip;
 
     this.rowCount = 0;
     this.colCount = 0;
@@ -309,6 +312,13 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
         var generatedHTML = '';
         this.attrClass = VALUE_CLASS_COLOR_TABLE + (this.attrClass == '' ? '' : ' ' + this.attrClass);
 
+        var colsLabels = MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount);
+        var rowsLabels = MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+        if (this.flip) {
+            colsLabels = colsLabels.split('').reverse().join('');
+            rowsLabels = rowsLabels.split('<br/>').filter(function (s) { return s !== ''; }).reverse().join('<br/>') + '<br/>';
+        }
+
         /* ----- Chess table -------------------------------------------------------- */
         generatedHTML +=
             '<table class="' + this.attrClass + '"' + (this.attrStyle != '' ? ' style="' + this.attrStyle + '"' : '') + '>';
@@ -320,7 +330,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
             generatedHTML +=
                 (this.isCoordShownLeft || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '<td class="cols">' +
-                MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount) +
+                colsLabels +
                 '</td>' +
                 (this.isCoordShownRight || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '';
@@ -342,7 +352,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
 
         if (this.isCoordShownLeft) {
             generatedHTML += '<td class="rows">';
-            generatedHTML += MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+            generatedHTML += rowsLabels;
             generatedHTML += '</td>';
         } else if (this.isCoordPadded) {
             generatedHTML += '<td class="rows">';
@@ -421,7 +431,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
 
         if (this.isCoordShownRight) {
             generatedHTML += '<td class="rows">';
-            generatedHTML += MERIDA_COORD_ROWS.substr((8 - this.coordOriginRow - this.rowCount) * 6, this.rowCount * 6);
+            generatedHTML += rowsLabels;
             generatedHTML += '</td>';
         } else if (this.isCoordPadded) {
             generatedHTML += '<td class="rows">';
@@ -438,7 +448,7 @@ function ChessBoard(_fenCode, _attrBorder, _colorMode, _attrStyle, _attrClass) {
             generatedHTML +=
                 (this.isCoordShownLeft || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '<td class="cols">' +
-                MERIDA_COORD_COLS.substr(this.coordOriginCol, this.colCount) +
+                colsLabels +
                 '</td>' +
                 (this.isCoordShownRight || this.isCoordPadded ? '<td>&nbsp;</td>' : '') +
                 '';
@@ -656,7 +666,8 @@ function parseChess() {
             boardFenCode = chessElt[idx].fenCode;
         }
 
-        var board = new ChessBoard(boardFenCode, attrBorder, attrMode, attrStyle, attrClass);
+        var attrFlip = chessElt[idx].getAttribute('data-flip') === '1';
+        var board = new ChessBoard(boardFenCode, attrBorder, attrMode, attrStyle, attrClass, attrFlip);
         var generatedHTML = board.generateHTML();
         if (generatedHTML.length == 0) {
             /* No board position given. Color mode is kept for upcoming chess tags. */
@@ -716,7 +727,10 @@ function applyFenToBoard() {
   // 5) Minimal DOM updates (textContent avoids accidental HTML parsing)
   const fig = document.getElementById('fen_fig');
   const toMove = document.getElementById('to_move');
-  if (fig) fig.textContent = oriented;
+  if (fig) {
+    fig.textContent = oriented;
+    fig.setAttribute('data-flip', side === 'w' ? '0' : '1');
+  }
   if (toMove) toMove.textContent = side === 'w' ? dict.white : dict.black;
 
   // 6) display moves string
@@ -733,9 +747,6 @@ function applyFenToBoard() {
 function fitChessBoardToScreen() {
   const table = document.querySelector('table.chess, table.bwchess');
   if (!table) return;
-
-  // Measure the real board box (more reliable than the table alone)
-  const board = table.querySelector('td.board > div.board') || table;
 
   // Reset any previous fitting
   table.style.zoom = '';
@@ -756,8 +767,9 @@ function fitChessBoardToScreen() {
   const maxW = Math.max(50, vw - margin * 2);
   const maxH = Math.max(50, vh - overhead - margin * 2);
 
-  // Measure actual current board size
-  const rect = board.getBoundingClientRect();
+  // Measure the full table (board + coordinate cells) so the right-hand
+  // coordinates never push the board off-screen when shown.
+  const rect = table.getBoundingClientRect();
 
   // Fit factor (never upscale; only shrink)
   let z = Math.min(maxW / rect.width, maxH / rect.height, 1);


### PR DESCRIPTION
## Summary

- **Coordinate flip (Black to move):** When the board is rotated 180° because it's Black's turn, the rank/file labels are now mirrored too. Previously the bottom-left square showed `a1`'s labels while it actually displayed `h8`. A `flip` flag is threaded from `applyFenToBoard` (via a `data-flip` attribute) through `parseChess` into `ChessBoard`, which reverses the column string (`abcdefgh` → `hgfedcba`) and the row string (`8…1` → `1…8`) inside `genColorHTML`. Applied to both `front.html` and `back.html`.
- **Coordinate overflow:** `fitChessBoardToScreen` now measures the full `table` (board **and** coordinate cells) instead of only the inner board div, so the right-hand coordinates no longer push the board off-screen when shown.
- **Sampling default:** lowered `target_per_theme` from 20 to 17 (defaults, docstrings, `main()` call, and `build_apkg.build_full`), reducing the number of puzzles per ELO tranche.
- **README:** updated the two stale `target_per_theme=20` references to 17.

## Test plan

- [x] `pytest tests/build_apkg_test.py` — 31 passed
- [x] Verified the flip transform produces `hgfedcba` (cols) and `1…8` top-to-bottom (rows), matching a 180°-rotated board
- [ ] Visual check in Anki: Black-to-move puzzle shows correctly mirrored coordinates
- [ ] Visual check: enabling coordinates on a narrow screen no longer overflows the board to the right

https://claude.ai/code/session_01VAUnQCt5CM2TVpRbsQbSBL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAUnQCt5CM2TVpRbsQbSBL)_